### PR TITLE
fix: Raise bear confidence threshold to 0.70

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -134,6 +134,7 @@ detection:
   class_confidence_overrides:
     person: 0.60  # Much higher to reduce false "person" detections
     bird: 0.55    # High threshold - telescope covers falsely detected as birds
+    bear: 0.70    # Very high - bears extremely rare in Mojave, rocks often misdetected
 
   # Size filtering (better than just confidence for distant wildlife!)
   # Note: Inference runs at 1920x1920 (3,686,400 total pixels)


### PR DESCRIPTION
Bears are extremely rare in Mojave desert. Rocks and shadows are frequently misdetected as bears. Require very high confidence (0.70) to reduce false positives.

**Per-class thresholds:**
- person: 0.60 (reduce false detections)
- bird: 0.55 (telescope covers)
- bear: 0.70 (rocks, very rare animal)

This follows Option 1 from false positive mitigation strategies.