### PR TITLE
fix: Increase dog detection threshold to 0.45

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -171,6 +171,7 @@ detection:
     person: 0.75  # Much higher to reduce false "person" detections
     bird: 0.55    # High threshold - telescope covers falsely detected as birds
     bear: 0.90    # Very high - bears extremely rare in Mojave, rocks often misdetected
+    dog: 0.45     # Reduce false positives from shadows
 
   # Size filtering (better than just confidence for distant wildlife!)
   # Note: Inference runs at 1920x1920 (3,686,400 total pixels)


### PR DESCRIPTION
## Problem
Shadows are being detected as dogs, causing false positives.

## Solution
Increase global dog confidence threshold from default 0.15 to 0.45.

## Notes
- cam2 already has dog: 0.65 override which remains unchanged
- This should reduce shadow false positives while still catching real dogs and coyotes
- Can adjust further if needed

## Testing
- Monitor detection logs after deployment
- Check if shadow false positives are reduced
- Verify real dog/coyote detections still work