### PR TITLE
feat: Add per-class size constraints to filter large bird false positives

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,16 @@ cameras:
     target_height: 1080  # Increased for better small object detection
     buffer_size: 1  # Keep at 1 for lowest latency
 
+    # Per-camera detection overrides
+    detection_overrides:
+      # Per-class size constraints (filter detections by bounding box area)
+      # Format: {min: pixels², max: pixels²}
+      # At 1920x1080 resolution: total pixels = 2,073,600
+      # Typical bird at distance: 200-5000px² | Large bird/hawk: 5000-15000px²
+      class_size_constraints:
+        bird:
+          max: 15000  # Max ~122x122 pixels - filters large false positives
+
   # Second camera (ground level - Reolink E1 Pro with better resolution)
   - id: "cam2"
     name: "Secondary View"

--- a/main.py
+++ b/main.py
@@ -259,6 +259,14 @@ class TelescopeDetectionSystem:
                         camera_detection_config['class_confidence_overrides'] = merged_class_overrides
                         logger.info(f"    class_confidence_overrides: {camera_class_overrides}")
 
+                    # Merge per-class size constraints (camera overrides take precedence)
+                    if 'class_size_constraints' in camera_overrides:
+                        merged_size_constraints = camera_detection_config.get('class_size_constraints', {}).copy()
+                        camera_size_constraints = camera_overrides['class_size_constraints']
+                        merged_size_constraints.update(camera_size_constraints)
+                        camera_detection_config['class_size_constraints'] = merged_size_constraints
+                        logger.info(f"    class_size_constraints: {camera_size_constraints}")
+
                 # Initialize per-camera two-stage pipeline (if enabled)
                 camera_two_stage_pipeline = None
                 if use_two_stage:


### PR DESCRIPTION
## Summary

Adds per-class bounding box size constraints to fix false positive bird detections on camera 1. Large objects (telescope covers, equipment, etc.) were being misclassified as birds.

## Changes

- **New Feature**: `class_size_constraints` config option
  - Supports per-class `min` and `max` bounding box area (pixels²)
  - Camera-specific overrides merge with global config
  - Filters detections after confidence thresholding

- **Config**: Added cam1 bird size constraint
  - Max: 15,000px² (~122x122 pixels at 1920x1080)
  - Catches real birds (200-15,000px²) while blocking large false positives
  - Camera 2 unaffected (uses global settings)

- **Implementation**:
  - `inference_engine_yolox.py`: Size filtering in `_run_inference()`
  - `main.py`: Config merging for `class_size_constraints`
  - `config.yaml`: Cam1 bird max size constraint

## Test Plan

- [x] Test on cam1 live feed - verify large objects no longer trigger bird detections
- [ ] Verify real birds (small/distant) still detected correctly
- [ ] Verify camera 2 behavior unchanged
- [ ] Check logs for size constraint messages during startup

## Typical Bird Sizes (1920x1080)

- Small distant birds: 200-1,000px²
- Medium birds: 1,000-5,000px²  
- Large birds/hawks: 5,000-15,000px²
- False positives: >15,000px²

## Performance Impact

Negligible - simple integer comparison per detection after existing confidence filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)