### PR TITLE
fix: Address issues #31, #29, #28, #39 - Queue logging, path resolution, env vars, resource cleanup

### DIFF
--- a/src/yolox_detector.py
+++ b/src/yolox_detector.py
@@ -3,13 +3,18 @@ YOLOX Detector - Fast Stage 1 detection (Apache 2.0 License)
 Replaces GroundingDINO for 47x faster inference (11.8ms vs 560ms)
 """
 import sys
-sys.path.insert(0, 'YOLOX')
-
 import torch
 import cv2
 import numpy as np
 import logging
 from typing import List, Dict, Any
+from pathlib import Path
+
+# Add YOLOX directory to sys.path dynamically (relative to this file)
+_yolox_path = Path(__file__).parent.parent / "YOLOX"
+if _yolox_path.exists() and str(_yolox_path) not in sys.path:
+    sys.path.insert(0, str(_yolox_path))
+
 from yolox.exp import get_exp
 from yolox.utils import postprocess
 from src.coco_constants import COCO_CLASSES, WILDLIFE_CLASSES, MAMMAL_CLASS_IDS


### PR DESCRIPTION
## Summary
Fixes four medium-priority bugs identified in comprehensive code review (#31, #29, #28, #39).

## Issues Fixed

### 1. Queue Full Exceptions Silently Ignored (#31) - **MEDIUM PRIORITY**
**Problem:** When output queues are full, exceptions were caught with bare `pass`, leading to silent data loss.

**Solution:**
- Added `dropped_results` counter to `InferenceEngine` and `DetectionProcessor`
- Log warning every 10th drop (avoids log spam while staying informed)
- Added `drop_rate` to statistics: `dropped_results / total_count`
- Users now aware when system is overloaded

**Impact:** No more silent data loss. Users can monitor drop rate via `/stats` endpoint.

---

### 2. Hardcoded sys.path Modification (#29) - **MEDIUM PRIORITY**
**Problem:** `yolox_detector.py` used hardcoded `sys.path.insert(0, 'YOLOX')` which:
- Assumes specific working directory
- Modifies global state at import time
- Could cause import conflicts

**Solution:**
- Dynamic path resolution using `Path(__file__).parent.parent / "YOLOX"`
- Only adds to `sys.path` if directory exists and not already present
- Works regardless of working directory

**Impact:** More robust imports, works in any environment (testing, deployment, IDE).

---

### 3. Global Environment Variable Pollution (#28) - **MEDIUM PRIORITY**
**Problem:** `RTSPStreamCapture.connect()` set global `OPENCV_FFMPEG_CAPTURE_OPTIONS`, affecting all OpenCV operations in the process.

**Solution:**
- Save existing environment variable before modification
- Restore original value after `VideoCapture` creation using try/finally
- Isolates each camera's configuration

**Impact:** Multi-camera setups can now use different protocols (one TCP, one UDP) without conflicts.

---

### 4. Resource Cleanup and Memory Leak Prevention (#39) - **MEDIUM PRIORITY**
**Problem:** Several components didn't properly clean up resources, potentially leading to memory leaks in long-running deployments.

**Solution:**
- Improved `VideoCapture.release()` with exception handling in `_reconnect()`
- Always set `capture=None` after release to prevent stale references
- Added memory usage tracking to all `get_stats()` methods:
  - System memory (RSS) via psutil
  - GPU memory (allocated/reserved) via torch.cuda
- Optional psutil integration (gracefully degrades if not installed)

**Impact:** Better resource management, memory monitoring for long-running deployments.

---

## Changes by File

### src/inference_engine_yolox.py
- Added `dropped_results` counter and logging
- Added `drop_rate` to stats
- Added GPU memory tracking (allocated/reserved)
- Added system memory tracking (RSS, percent)

### src/detection_processor.py
- Added `dropped_results` counter and logging
- Added `drop_rate` to stats
- Added system memory tracking

### src/yolox_detector.py
- Replaced hardcoded `sys.path.insert(0, 'YOLOX')`
- Dynamic path resolution using `Path(__file__).parent.parent / "YOLOX"`
- Check if path exists and not already in sys.path

### src/stream_capture.py
- Save/restore `OPENCV_FFMPEG_CAPTURE_OPTIONS` using try/finally
- Improved `_reconnect()` with proper exception handling
- Always set `capture=None` after release
- Added system memory tracking to stats

---

## Testing
- ✅ All modified files pass Python syntax checks
- ✅ Memory tracking available via `/stats` endpoint
- ✅ Queue drops now logged and tracked
- ✅ Works with or without psutil installed

## Statistics Additions

New fields available in `/stats` endpoint:
```json
{
  "inference_engine": {
    "dropped_results": 42,
    "drop_rate": 0.001,
    "gpu_memory_allocated_mb": 245.3,
    "gpu_memory_reserved_mb": 512.0,
    "memory_mb": 1234.5,
    "memory_percent": 15.2
  },
  "detection_processor": {
    "dropped_results": 5,
    "drop_rate": 0.0002,
    "memory_mb": 567.8,
    "memory_percent": 7.1
  },
  "stream_capture": {
    "memory_mb": 89.2,
    "memory_percent": 1.1
  }
}
```

---

## Related Issues
Closes #31
Closes #29
Closes #28
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)