### PR TITLE
fix: Replace busy waiting with blocking queue.get() (Issue #27)

### DIFF
--- a/src/detection_processor.py
+++ b/src/detection_processor.py
@@ -7,7 +7,7 @@ import time
 import logging
 from datetime import datetime
 from typing import List, Dict, Any, Optional
-from queue import Queue
+from queue import Queue, Empty
 from threading import Thread, Event
 from collections import deque
 from visualization_utils import draw_detections
@@ -126,12 +126,11 @@ class DetectionProcessor:
 
         while not self.stop_event.is_set():
             try:
-                # Get detections from input queue
-                if self.input_queue.empty():
-                    time.sleep(0.001)
+                # Get detections from input queue (blocking with timeout)
+                try:
+                    detection_result = self.input_queue.get(timeout=0.1)
+                except Empty:
                     continue
-
-                detection_result = self.input_queue.get()
 
                 # Get current frame for motion filtering (thread-safe)
                 current_frame = self._get_frame_copy()

--- a/src/inference_engine_yolox.py
+++ b/src/inference_engine_yolox.py
@@ -8,7 +8,7 @@ import torch
 import time
 import logging
 from typing import Optional, List, Dict, Any
-from queue import Queue
+from queue import Queue, Empty
 from threading import Thread, Event
 import numpy as np
 
@@ -166,12 +166,12 @@ class InferenceEngine:
 
         while not self.stop_event.is_set():
             try:
-                # Get frame from input queue (non-blocking)
-                if self.input_queue.empty():
-                    time.sleep(0.001)  # Small sleep to avoid busy waiting
+                # Get frame from input queue (blocking with timeout)
+                try:
+                    frame_data = self.input_queue.get(timeout=0.1)
+                except Empty:
                     continue
 
-                frame_data = self.input_queue.get()
                 frame = frame_data['frame']
                 frame_timestamp = frame_data['timestamp']
                 frame_id = frame_data['frame_id']


### PR DESCRIPTION
## Summary
Addresses issue #27 - Eliminates CPU waste from busy waiting in inference and processing loops.

**Changes:**
- Replace `queue.empty()` check + `time.sleep(0.001)` with blocking `queue.get(timeout=0.1)`
- Add `Empty` import from queue module for proper exception handling
- Applied to both inference engine and detection processor loops

**Files Modified:**
- `src/inference_engine_yolox.py:167-173`
- `src/detection_processor.py:127-133`

## Benefits
- **No more CPU waste**: Threads now properly block instead of spinning with short sleeps
- **Better scalability**: With multiple cameras, this eliminates N busy-wait loops consuming CPU
- **Same responsiveness**: 100ms timeout still allows checking `stop_event` frequently
- **Standard Python pattern**: Uses idiomatic producer-consumer queue pattern

## Performance Impact
**Before:** Each camera had 2 threads spinning with 1ms sleeps when queues were empty, wasting CPU cycles checking empty queues thousands of times per second.

**After:** Threads block efficiently until data is available or 100ms timeout expires, consuming minimal CPU when idle.

For a 2-camera setup: Eliminates ~4 busy-wait loops (2 inference + 2 processing)

## Testing
✅ Service restarted successfully with new implementation  
✅ Both inference loops started and running (cam1 & cam2)  
✅ Both processing loops started and running (cam1 & cam2)  
✅ System operational with 280 threads active  
✅ No errors or warnings from queue operations  
✅ Python syntax validation passed

## Test Plan
- [x] Code compiles without syntax errors
- [x] Service restarts successfully
- [x] Inference loops start for all cameras
- [x] Processing loops start for all cameras
- [x] System continues to detect and process frames
- [x] No performance degradation observed

## Closes
Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)