### PR TITLE
fix: Add missing Dict and Any imports from typing

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import signal
 import threading
 from pathlib import Path
 from queue import Queue, Empty
-from typing import Optional
+from typing import Optional, Dict, Any
 import yaml
 
 # Add src directory to path


### PR DESCRIPTION
## Critical Hotfix

Fixes NameError preventing system startup after hot-reload PR (#85) was merged.

### Error
```
NameError: name 'Dict' is not defined. Did you mean: 'dict'?
  File "/home/damen/telescope_cam_detection/main.py", line 389, in TelescopeDetectionSystem
    def reload_config(self) -> Dict[str, Any]:
```

### Fix
Added missing `Dict` and `Any` imports from typing module in main.py:14.

### Testing
- ✅ Service starts successfully after fix
- ✅ No import errors
- ✅ Hot-reload functionality intact

**Before:**
```python
from typing import Optional
```

**After:**
```python
from typing import Optional, Dict, Any
```

This was an oversight in PR #85 - the type annotations used `Dict[str, Any]` but the imports weren't updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)