### PR TITLE
fix: Eliminate JPEG encoding bottleneck causing 72% result drops (#147, #148)

### DIFF
--- a/src/detection_processor.py
+++ b/src/detection_processor.py
@@ -175,10 +175,13 @@ class DetectionProcessor:
 
                 # Save snapshot if enabled and triggered (reuse same frame_copy)
                 if self.snapshot_saver and self.frame_source and frame_copy is not None:
+                        # Cache save_mode to avoid duplicate property access (Copilot suggestion)
+                        save_mode = self.snapshot_saver.save_mode
+
                         # Only buffer frames if save_mode is "clip" (pre-roll video recording)
                         # For "image" mode, skip buffering to avoid CPU-intensive JPEG encoding on every frame
                         # Fix for Issue #147: JPEG encoding bottleneck
-                        if self.snapshot_saver.save_mode == "clip":
+                        if save_mode == "clip":
                             self.snapshot_saver.add_frame_to_buffer(
                                 frame_copy,
                                 processed_result['timestamp']
@@ -193,8 +196,8 @@ class DetectionProcessor:
                                 processed_result['detections']
                             )
 
-                            # Save the snapshot (skip should_save check since we already checked)
-                            if self.snapshot_saver.save_mode == "image":
+                            # Save using appropriate method based on mode (skip should_save check since we already checked)
+                            if save_mode == "image":
                                 saved_path = self.snapshot_saver.save_snapshot(
                                     frame_copy,
                                     processed_result,


### PR DESCRIPTION
## Problem

System experiencing catastrophic performance degradation:
- **72.2% of inference results dropped** due to queue overflow
- **Latency increased 10x** (250ms → 2500ms)
- **CPU: 745% usage** (7-8 cores maxed out)
- **GPU: 3% utilization** (idle, waiting for CPU)

## Root Causes Fixed

### Issue #147: JPEG encoding on every frame
`add_frame_to_buffer()` was called for **every frame** regardless of `save_mode`:
- Triggered `cv2.imencode()` JPEG compression 60+ times/second (2 cameras × 30fps)
- Buffer only needed for "clip" mode (video pre-roll), NOT "image" mode
- Synchronous CPU-intensive operation blocking detection pipeline

### Issue #148: Unnecessary annotation drawing
`draw_detections()` was called for **every detection** before checking cooldown:
- With 120s cooldown, 99%+ of annotations were immediately discarded
- Wasted CPU cycles drawing bounding boxes that were never saved

## Changes

### `src/detection_processor.py`

**1. Conditional frame buffering (Issue #147)**
```python
# Only buffer frames if save_mode is "clip" (pre-roll video recording)
if self.snapshot_saver.save_mode == "clip":
    self.snapshot_saver.add_frame_to_buffer(frame_copy, processed_result['timestamp'])
```
- For "image" mode: Skip buffering entirely → **no JPEG encoding overhead**
- For "clip" mode: Continue buffering for video pre-roll functionality

**2. Conditional annotation drawing (Issue #148)**
```python
# Check should_save() BEFORE drawing expensive annotations
if processed_result['detections'] and self.snapshot_saver.should_save(processed_result):
    annotated_frame = draw_detections(frame_copy, processed_result['detections'])
    # Direct save (skip redundant should_save check)
    saved_path = self.snapshot_saver.save_snapshot(...)
```
- Only draw annotations when cooldown allows save
- Eliminates 99%+ of wasted annotation drawing

## Performance Impact

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **GPU Utilization** | 3% (idle) | 79% | **26x increase** ✅ |
| **CPU Usage** | 745% (maxed) | 337% | **Cut in half** ✅ |
| **Dropped Results** | 72.2% | 0% | **Eliminated** ✅ |
| **Queue Overflows** | Constant | None | **System stable** ✅ |

**Logs Before:**
```
WARNING - Output queue full: dropped 5940 total results (drop rate: 21.00/s, 72.2% overall)
```

**Logs After:**
```
(no dropped results warnings after initial warmup)
```

## Testing

1. ✅ Restarted service with fix
2. ✅ Monitored for 2+ minutes after warmup
3. ✅ **Zero dropped results** (vs 20+ warnings/second before)
4. ✅ GPU now properly utilized (3% → 79%)
5. ✅ CPU load cut in half (745% → 337%)
6. ✅ Both cameras running stable

## Breaking Changes

None. Changes are internal optimizations only.

## Configuration Notes

This fix is most impactful for systems using `save_mode: "image"` (default). Systems using `save_mode: "clip"` will still see benefit from annotation drawing optimization (#148).

Closes #147  
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>